### PR TITLE
feat: make emit safe

### DIFF
--- a/adonis-typings/events.ts
+++ b/adonis-typings/events.ts
@@ -84,8 +84,8 @@ declare module '@ioc:Adonis/Core/Event' {
 		/**
 		 * Emit an event
 		 */
-		emit<K extends keyof EventsList>(event: K, data: EventsList[K]): Promise<void>
-		emit<K extends string>(event: K, data: DataForEvent<K>): Promise<void>
+		emit<K extends keyof EventsList>(event: K, data: EventsList[K]): void
+		emit<K extends string>(event: K, data: DataForEvent<K>): void
 
 		/**
 		 * Remove event listener

--- a/npm-audit.html
+++ b/npm-audit.html
@@ -55,7 +55,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            October 24th 2020, 11:49:26 am
+                            October 29th 2020, 1:25:32 pm
                         </h5>
                         <p class="card-text">Last updated</p>
                     </div>


### PR DESCRIPTION
## Proposed changes

Currently, `Event.emit` returns a Promise that developers must handle in their controllers. If they don't, since Node.js 15.0.0, it crashes the whole Adonis app.
The proposal doesn't return the promise anymore and let Adonis handle errors that could happen during the event listener execution.

Two assumptions are made:
- Event handling mustn't disrupt the controller by throwing an error.
- Developer shouldn't have to manually handle errors on Event emitting.

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/events/blob/master/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

