### PR TITLE
feat(emitter): add listenIf method

### DIFF
--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -232,6 +232,31 @@ export class Emitter<EventsList extends Record<string | symbol | number, any>>
   }
 
   /**
+   * Listen for an event depending on a condition
+   */
+  listenIf<Event extends Constructor, ListenerClass extends Constructor>(
+    condition: boolean | (() => boolean),
+    event: Event,
+    listener: Listener<InstanceType<Event>, ListenerClass>
+  ): UnsubscribeFunction
+  listenIf<Name extends keyof EventsList, ListenerClass extends Constructor>(
+    condition: boolean | (() => boolean),
+    event: Name,
+    listener: Listener<EventsList[Name], ListenerClass>
+  ): UnsubscribeFunction
+  listenIf<Event extends AllowedEventTypes>(
+    condition: boolean | (() => boolean),
+    event: Event,
+    listener: Listener<any, Constructor>
+  ): UnsubscribeFunction {
+    if (condition === false || (typeof condition === 'function' && !condition())) {
+      return () => {}
+    }
+
+    return this.on(event, listener)
+  }
+
+  /**
    * Listen for an event only once
    */
   once<Event extends Constructor, ListenerClass extends Constructor>(

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -249,10 +249,11 @@ export class Emitter<EventsList extends Record<string | symbol | number, any>>
     event: Event,
     listener: Listener<any, Constructor>
   ): UnsubscribeFunction {
-    if (condition === false || (typeof condition === 'function' && !condition())) {
+    if (!condition || (typeof condition === 'function' && !condition())) {
       return () => {}
     }
 
+    // @ts-expect-error - TypeScript does not like overloading
     return this.on(event, listener)
   }
 

--- a/tests/emitter/listen.spec.ts
+++ b/tests/emitter/listen.spec.ts
@@ -35,6 +35,26 @@ test.group('Emitter | listen', () => {
     assert.equal(emitter.eventsListeners.get('new:user')?.size, 1)
   })
 
+  test('listen for an event depending on a condition', async ({ assert }) => {
+    const stack: any[] = []
+
+    const app = new Application(BASE_URL, { environment: 'web' })
+    const emitter = new Emitter(app)
+
+    emitter.listenIf(true, 'new:user', (data) => {
+      stack.push(data)
+    })
+
+    emitter.listenIf(false, 'new:user2', (data) => {
+      stack.push(data)
+    })
+
+    await emitter.emit('new:user', { id: 1 })
+    await emitter.emit('new:user2', { id: 1 })
+    assert.deepEqual(stack, [{ id: 1 }])
+    assert.equal(emitter.eventsListeners.get('new:user')?.size, 1)
+  })
+
   test('do not register multiple listeners when callback is the same', async ({ assert }) => {
     const stack: any[] = []
 


### PR DESCRIPTION
Hey there! 👋🏻 

This PR adds the `listenIf` method. This method allows listening to an event only if the condition returns `true`.

Instead of...
```ts
if (app.inDev) {
  emitter.on(...)
}
```

You can write:
```ts
emitter.listenIf(app.inDev, () => {})
```

It seems that TypeScript is not happy about the overloading when calling `this.on()`, I am not sure how to fix that.